### PR TITLE
fix:  Improve speed of kdtree grouping by pointops

### DIFF
--- a/sam3d.py
+++ b/sam3d.py
@@ -179,13 +179,15 @@ def cal_2_scenes(pcd_list, index, voxel_size, voxelize, th=50):
         return input_dict_0
 
     # Cal Dul-overlap
-    pcd0_tree = o3d.geometry.KDTreeFlann(copy.deepcopy(pcd0))
-    match_inds = get_matching_indices(pcd1, pcd0_tree, 1.5 * voxel_size, 1)
+    # pcd0_tree = o3d.geometry.KDTreeFlann(copy.deepcopy(pcd0))
+    # match_inds = get_matching_indices(pcd1, pcd0_tree, 1.5 * voxel_size, 1)
+    match_inds = get_matching_indices(pcd1, pcd0, 1.5 * voxel_size, 1)
     pcd1_new_group = cal_group(input_dict_0, input_dict_1, match_inds)
     # print(pcd1_new_group)
 
-    pcd1_tree = o3d.geometry.KDTreeFlann(copy.deepcopy(pcd1))
-    match_inds = get_matching_indices(pcd0, pcd1_tree, 1.5 * voxel_size, 1)
+    # pcd1_tree = o3d.geometry.KDTreeFlann(copy.deepcopy(pcd1))
+    # match_inds = get_matching_indices(pcd0, pcd1_tree, 1.5 * voxel_size, 1)
+    match_inds = get_matching_indices(pcd1, pcd0, 1.5 * voxel_size, 1)
     input_dict_1["group"] = pcd1_new_group
     pcd0_new_group = cal_group(input_dict_1, input_dict_0, match_inds)
     # print(pcd0_new_group)

--- a/sam3d.py
+++ b/sam3d.py
@@ -179,14 +179,10 @@ def cal_2_scenes(pcd_list, index, voxel_size, voxelize, th=50):
         return input_dict_0
 
     # Cal Dul-overlap
-    # pcd0_tree = o3d.geometry.KDTreeFlann(copy.deepcopy(pcd0))
-    # match_inds = get_matching_indices(pcd1, pcd0_tree, 1.5 * voxel_size, 1)
     match_inds = get_matching_indices(pcd1, pcd0, 1.5 * voxel_size, 1)
     pcd1_new_group = cal_group(input_dict_0, input_dict_1, match_inds)
     # print(pcd1_new_group)
 
-    # pcd1_tree = o3d.geometry.KDTreeFlann(copy.deepcopy(pcd1))
-    # match_inds = get_matching_indices(pcd0, pcd1_tree, 1.5 * voxel_size, 1)
     match_inds = get_matching_indices(pcd1, pcd0, 1.5 * voxel_size, 1)
     input_dict_1["group"] = pcd1_new_group
     pcd0_new_group = cal_group(input_dict_1, input_dict_0, match_inds)

--- a/sam3d.py
+++ b/sam3d.py
@@ -183,7 +183,7 @@ def cal_2_scenes(pcd_list, index, voxel_size, voxelize, th=50):
     pcd1_new_group = cal_group(input_dict_0, input_dict_1, match_inds)
     # print(pcd1_new_group)
 
-    match_inds = get_matching_indices(pcd1, pcd0, 1.5 * voxel_size, 1)
+    match_inds = get_matching_indices(pcd0, pcd1, 1.5 * voxel_size, 1)
     input_dict_1["group"] = pcd1_new_group
     pcd0_new_group = cal_group(input_dict_1, input_dict_0, match_inds)
     # print(pcd0_new_group)

--- a/util.py
+++ b/util.py
@@ -207,6 +207,8 @@ def get_matching_indices(pcd0, pcd1, search_voxel_size, K=None):
     for i in range(scene_coord.shape[0]):
         if dis[i] < search_voxel_size:
             match_inds.append([i,indices[i]])
+    
+    return match_inds
 
     
 

--- a/util.py
+++ b/util.py
@@ -6,6 +6,7 @@ import copy
 from PIL import Image
 import json
 # import clip
+import pointops
 
 
 SCANNET_COLOR_MAP_20 = {-1: (0., 0., 0.), 0: (174., 199., 232.), 1: (152., 223., 138.), 2: (31., 119., 180.), 3: (255., 187., 120.), 4: (188., 189., 34.), 5: (140., 86., 75.),
@@ -192,16 +193,22 @@ def num_to_natural(group_ids):
     return array
 
 
-def get_matching_indices(source, pcd_tree, search_voxel_size, K=None):
+def get_matching_indices(pcd0, pcd1, search_voxel_size, K=None):
     match_inds = []
-    for i, point in enumerate(source.points):
-        [_, idx, _] = pcd_tree.search_radius_vector_3d(point, search_voxel_size)
-        if K is not None:
-            idx = idx[:K]
-        for j in idx:
-            # match_inds[i, j] = 1
-            match_inds.append((i, j))
-    return match_inds
+    scene_coord = torch.tensor(np.asarray(pcd0.points)).cuda().contiguous().float()
+    new_offset = torch.tensor(scene_coord.shape[0]).cuda().float()
+    gen_coord = torch.tensor(np.asarray(pcd1.points)).cuda().contiguous().float()
+    offset = torch.tensor(gen_coord.shape[0]).cuda().float()
+
+    indices, dis = pointops.knn_query(1, gen_coord, offset, scene_coord, new_offset)
+    indices = indices.cpu().numpy()[:,0]
+    dis = dis.cpu().numpy()[:,0]
+
+    for i in range(scene_coord.shape[0]):
+        if dis[i] < search_voxel_size:
+            match_inds.append([i,indices[i]])
+
+    
 
 
 def visualize_3d(data_dict, text_feat_path, save_path):


### PR DESCRIPTION
Thanks for your nice work.

When the point count is too large, CPU loop querying for the nearest points becomes too slow. It is recommended to switch to point operations querying