### PR TITLE
Add scripts for point cloud data captured from 3d scanner app

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ python scannet-preprocess/preprocess_scannet.py --dataset_root ${RAW_SCANNET_DIR
 python scannet-preprocess/prepare_2d_data/prepare_2d_data.py --scannet_path data/scannetv2 --output_path data/scannetv2_images --export_label_images
 ```
 
+### 3d Scanner App
+If you have an iPhone or iPad with a LiDAR senser, you can use [3d Scanner App](https://apps.apple.com/us/app/id1419913995) from App Store.
+This app generates necessary information including color images, depth images, poses and intrinsics. \
+Run preprocessing code for sampled data as follows:
+- `DATA_DIR`: the directory to be processed and it should contains frame_XXX.jpg(s), frame_XXX.json(s), depth_XXX.png(s), points.ply.
+- `PROCESSED_PATH`: the directory of processed data, which contains color, depth, pose, intrinsics directory and a points.pth file.
+```
+python preprocess_3d_scan.py --data_path ${DATA_DIR} --save_path ${PROCESSED_PATH}
+```
+
+
 ## Getting Started
 Please try it via [sam3d.py](./sam3d.py)
 ```
@@ -54,6 +65,16 @@ Please try it via [sam3d.py](./sam3d.py)
 # SAM_CHECKPOINT_PATH: the path of checkpoint for SAM
 
 python sam3d.py --rgb_path $RGB_PATH --data_path $DATA_PATH --save_path $SAVE_PATH --save_2dmask_path $SAVE_2DMASK_PATH --sam_checkpoint_path $SAM_CHECKPOINT_PATH 
+```
+
+### Custom data from 3D Scanner App
+Try it via [sam3d_custom.py](./sam3d_custom.py)
+- `PROCESSED_PATH`: the directory of processed data.
+- `SAVE_DIR`: Where to save the results. The results contain 2D segmentation images, result.pth, and result.ply.
+- `SAM_CHECKPOINT_PATH`: the path of checkpoint for SAM.
+
+```
+python sam3d_custom.py --data_path $PROCESSED_PATH --save_path $SAVE_DIR --sam_checkpoint_path $SAM_CHECKPOINT_PATH
 ```
 
 ## Pipeline

--- a/preprocess_3d_scan.py
+++ b/preprocess_3d_scan.py
@@ -1,0 +1,95 @@
+import argparse
+from pathlib import Path
+import shutil
+import numpy as np
+import json
+import open3d as o3d
+import torch
+
+def save_mat_to_file(matrix: np.ndarray, filename: str):
+    with open(filename, 'w') as f:
+        for line in matrix:
+            np.savetxt(f, line[np.newaxis], fmt='%f')
+
+def get_args():
+    '''Command line arguments.'''
+
+    parser = argparse.ArgumentParser(
+        description='Segment from 3D scanner app')
+    dps_help = 'Point cloud data from App Store 3D scanner App https://apps.apple.com/us/app/id1419913995, '
+    dps_help += 'which contains frame_X.jpg(s), depth_X.png(s), frame_X.json(s) and points.ply'
+    parser.add_argument('--data_path', type=str, help=dps_help)
+
+    sv_help = "Save path will be created and contains these things: color, depth, pose, intrinsics directory and points.pth."
+    parser.add_argument('--save_path', type=str, help=sv_help)
+
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = get_args()
+
+    data_dir = Path(args.data_path)
+    frame_jpg_paths = data_dir.glob("frame_[0-9]*.jpg")
+    frame_json_paths = data_dir.glob("frame_[0-9]*.json")
+    depth_paths = data_dir.glob("depth_[0-9]*.png")
+
+
+    # Generate output directories
+    output_dir = Path(args.save_path)
+    output_dir.mkdir(exist_ok=True)
+
+    color_path = (output_dir / "color")
+    color_path.mkdir(exist_ok=True)
+
+    depth_path = (output_dir / "depth")
+    depth_path.mkdir(exist_ok=True)
+
+    intrinsics_path = (output_dir / "intrinsics")
+    intrinsics_path.mkdir(exist_ok=True)
+
+    pose_path = (output_dir / "pose")
+    pose_path.mkdir(exist_ok=True)
+
+    # Copy image files
+    for pp in frame_jpg_paths:
+        shutil.copy(pp, color_path)
+    for pp in depth_paths:
+        dest = depth_path / ("frame_" + pp.name[6:])
+        shutil.copy(pp, dest)
+    
+
+    # Create and copy intrinsic_depth.txt
+    first_json_path = next(iter(frame_json_paths))
+    intrinsics_txt_path = intrinsics_path / "intrinsic_depth.txt"
+    with open(str(first_json_path)) as f:
+        jj = json.load(f)
+    intrinsics = jj['intrinsics']
+    intrinsics = np.array(intrinsics)
+    intrinsics = intrinsics.reshape([3, 3]).astype(np.float32)
+    rr = np.eye(4, dtype=np.float32)
+    rr[0:3, 0:3] = intrinsics
+    save_mat_to_file(rr, str(intrinsics_txt_path))
+
+    # Pose
+    for pp in frame_json_paths:
+        with open(str(pp)) as f:
+            jj = json.load(f)
+        pose = jj['cameraPoseARFrame']
+        pose = np.array(pose, dtype=np.float32).reshape([4, 4])
+        dest = pose_path / ("frame_" + pp.name[6:-5] + ".txt")
+        save_mat_to_file(pose, str(dest))
+
+    # .ply to .pth
+    ply_path = data_dir / "points.ply"
+    pcd = o3d.io.read_point_cloud(str(ply_path))
+    coords = np.asarray(pcd.points)
+    colors = np.asarray(pcd.colors)
+    save_dict = dict(coord=coords, color=colors, scene_id=data_dir.stem)
+    dest = output_dir / "points.pth"
+    torch.save(save_dict, str(dest))
+    pass
+
+if __name__ == '__main__':
+    main()
+    pass

--- a/sam3d_custom.py
+++ b/sam3d_custom.py
@@ -1,0 +1,300 @@
+"""
+Main Script
+
+Author: Yunhan Yang (yhyang.myron@gmail.com)
+"""
+
+import os
+import cv2
+import numpy as np
+import open3d as o3d
+import torch
+import copy
+import multiprocessing as mp
+import pointops
+import random
+import argparse
+
+from segment_anything import build_sam, SamAutomaticMaskGenerator
+from concurrent.futures import ProcessPoolExecutor
+from itertools import repeat
+from PIL import Image
+from os.path import join
+from util import *
+from pathlib import Path
+import open3d as o3d
+
+
+def pcd_ensemble(org_path, new_path, data_path, vis_path):
+    new_pcd = torch.load(new_path)
+    new_pcd = num_to_natural(remove_small_group(new_pcd, 20))
+    with open(org_path) as f:
+        segments = json.load(f)
+        org_pcd = np.array(segments['segIndices'])
+    match_inds = [(i, i) for i in range(len(new_pcd))]
+    new_group = cal_group(dict(group=new_pcd), dict(group=org_pcd), match_inds)
+    print(new_group.shape)
+    data = torch.load(data_path)
+    visualize_partition(data["coord"], new_group, vis_path)
+
+
+def get_sam(image, mask_generator):
+    masks = mask_generator.generate(image)
+    group_ids = np.full((image.shape[0], image.shape[1]), -1, dtype=int)
+    num_masks = len(masks)
+    group_counter = 0
+    for i in reversed(range(num_masks)):
+        # print(masks[i]["predicted_iou"])
+        group_ids[masks[i]["segmentation"]] = group_counter
+        group_counter += 1
+    return group_ids
+
+def get_pcd_custom(color_image_path: Path, data_path: Path, save_path: Path, mask_generator):
+    intrinsic_path = data_path / "intrinsics" / "intrinsic_depth.txt"
+    intrinsic_path = str(intrinsic_path)
+    
+    depth_intrinsic = np.loadtxt(intrinsic_path)
+
+    color_stem = color_image_path.stem
+    color = str(color_image_path)
+    pose = data_path / "pose" / (color_stem + ".txt")
+    pose = str(pose)
+    depth = data_path / "depth" / (color_stem + ".png")
+    depth = str(depth)
+
+    depth_img = cv2.imread(depth, -1) # read 16bit grayscale image
+    depth_img = cv2.resize(depth_img, (640, 480))
+    mask = (depth_img != 0)
+    color_image = cv2.imread(color)
+    color_image = cv2.resize(color_image, (640, 480))
+
+    save_2dmask_path = save_path / "mask2d"
+    save_2dmask_path = str(save_2dmask_path)
+    if mask_generator is not None:
+        group_ids = get_sam(color_image, mask_generator)
+        if not os.path.exists(save_2dmask_path):
+            os.makedirs(save_2dmask_path)
+        img = Image.fromarray(num_to_natural(group_ids).astype(np.int16), mode='I;16')
+        img.save(join(save_2dmask_path, color_stem + '.png'))
+    else:
+        group_path = join(save_2dmask_path, color_stem + '.png')
+        img = Image.open(group_path)
+        group_ids = np.array(img, dtype=np.int16)
+
+    color_image = np.reshape(color_image[mask], [-1,3])
+    group_ids = group_ids[mask]
+    colors = np.zeros_like(color_image)
+    colors[:,0] = color_image[:,2]
+    colors[:,1] = color_image[:,1]
+    colors[:,2] = color_image[:,0]
+
+    pose = np.loadtxt(pose)
+    
+    depth_shift = 1000.0
+    x,y = np.meshgrid(np.linspace(0,depth_img.shape[1]-1,depth_img.shape[1]), np.linspace(0,depth_img.shape[0]-1,depth_img.shape[0]))
+    uv_depth = np.zeros((depth_img.shape[0], depth_img.shape[1], 3))
+    uv_depth[:,:,0] = x
+    uv_depth[:,:,1] = y
+    uv_depth[:,:,2] = depth_img/depth_shift
+    uv_depth = np.reshape(uv_depth, [-1,3])
+    uv_depth = uv_depth[np.where(uv_depth[:,2]!=0),:].squeeze()
+    
+    intrinsic_inv = np.linalg.inv(depth_intrinsic)
+    fx = depth_intrinsic[0,0]
+    fy = depth_intrinsic[1,1]
+    cx = depth_intrinsic[0,2]
+    cy = depth_intrinsic[1,2]
+    bx = depth_intrinsic[0,3]
+    by = depth_intrinsic[1,3]
+    n = uv_depth.shape[0]
+    points = np.ones((n,4))
+    X = (uv_depth[:,0]-cx)*uv_depth[:,2]/fx + bx
+    Y = (uv_depth[:,1]-cy)*uv_depth[:,2]/fy + by
+    points[:,0] = X
+    points[:,1] = Y
+    points[:,2] = uv_depth[:,2]
+    points_world = np.dot(points, np.transpose(pose))
+    group_ids = num_to_natural(group_ids)
+    save_dict = dict(coord=points_world[:,:3], color=colors, group=group_ids)
+    return save_dict
+
+
+def make_open3d_point_cloud(input_dict, voxelize, th):
+    input_dict["group"] = remove_small_group(input_dict["group"], th)
+    # input_dict = voxelize(input_dict)
+
+    xyz = input_dict["coord"]
+    if np.isnan(xyz).any():
+        return None
+    pcd = o3d.geometry.PointCloud()
+    pcd.points = o3d.utility.Vector3dVector(xyz)
+    return pcd
+
+
+def cal_group(input_dict, new_input_dict, match_inds, ratio=0.5):
+    group_0 = input_dict["group"]
+    group_1 = new_input_dict["group"]
+    group_1[group_1 != -1] += group_0.max() + 1
+    
+    unique_groups, group_0_counts = np.unique(group_0, return_counts=True)
+    group_0_counts = dict(zip(unique_groups, group_0_counts))
+    unique_groups, group_1_counts = np.unique(group_1, return_counts=True)
+    group_1_counts = dict(zip(unique_groups, group_1_counts))
+
+    # Calculate the group number correspondence of overlapping points
+    group_overlap = {}
+    for i, j in match_inds:
+        group_i = group_1[i]
+        group_j = group_0[j]
+        if group_i == -1:
+            group_1[i] = group_0[j]
+            continue
+        if group_j == -1:
+            continue
+        if group_i not in group_overlap:
+            group_overlap[group_i] = {}
+        if group_j not in group_overlap[group_i]:
+            group_overlap[group_i][group_j] = 0
+        group_overlap[group_i][group_j] += 1
+
+    # Update group information for point cloud 1
+    for group_i, overlap_count in group_overlap.items():
+        # for group_j, count in overlap_count.items():
+        max_index = np.argmax(np.array(list(overlap_count.values())))
+        group_j = list(overlap_count.keys())[max_index]
+        count = list(overlap_count.values())[max_index]
+        total_count = min(group_0_counts[group_j], group_1_counts[group_i]).astype(np.float32)
+        # print(count / total_count)
+        if count / total_count >= ratio:
+            group_1[group_1 == group_i] = group_j
+    return group_1
+
+
+def cal_2_scenes(pcd_list, index, voxel_size, voxelize, th=50):
+    if len(index) == 1:
+        return(pcd_list[index[0]])
+    # print(index, flush=True)
+    input_dict_0 = pcd_list[index[0]]
+    input_dict_1 = pcd_list[index[1]]
+    pcd0 = make_open3d_point_cloud(input_dict_0, voxelize, th)
+    pcd1 = make_open3d_point_cloud(input_dict_1, voxelize, th)
+    if pcd0 == None:
+        if pcd1 == None:
+            return None
+        else:
+            return input_dict_1
+    elif pcd1 == None:
+        return input_dict_0
+
+    # Cal Dul-overlap
+    pcd0_tree = o3d.geometry.KDTreeFlann(copy.deepcopy(pcd0))
+    match_inds = get_matching_indices(pcd1, pcd0_tree, 1.5 * voxel_size, 1)
+    pcd1_new_group = cal_group(input_dict_0, input_dict_1, match_inds)
+    # print(pcd1_new_group)
+
+    pcd1_tree = o3d.geometry.KDTreeFlann(copy.deepcopy(pcd1))
+    match_inds = get_matching_indices(pcd0, pcd1_tree, 1.5 * voxel_size, 1)
+    input_dict_1["group"] = pcd1_new_group
+    pcd0_new_group = cal_group(input_dict_1, input_dict_0, match_inds)
+    # print(pcd0_new_group)
+
+    pcd_new_group = np.concatenate((pcd0_new_group, pcd1_new_group), axis=0)
+    pcd_new_group = num_to_natural(pcd_new_group)
+    pcd_new_coord = np.concatenate((input_dict_0["coord"], input_dict_1["coord"]), axis=0)
+    pcd_new_color = np.concatenate((input_dict_0["color"], input_dict_1["color"]), axis=0)
+    pcd_dict = dict(coord=pcd_new_coord, color=pcd_new_color, group=pcd_new_group)
+
+    pcd_dict = voxelize(pcd_dict)
+    return pcd_dict
+
+def seg_pcd_custom(data_path: Path, save_Path: Path, mask_generator, voxel_size, voxelize, th, ):
+    color_directory = data_path / "color"
+    color_image_paths = color_directory.glob("*.jpg")
+    pcd_list = []
+    for ci_path in color_image_paths:
+        pcd_dict = get_pcd_custom(ci_path, data_path, save_Path, mask_generator)
+        if len(pcd_dict["coord"]) == 0:
+            continue
+        pcd_dict = voxelize(pcd_dict)
+        pcd_list.append(pcd_dict)
+        print("Processed:", str(ci_path))
+    pass
+
+    while len(pcd_list) != 1:
+        print(len(pcd_list), flush=True)
+        new_pcd_list = []
+        for indice in pairwise_indices(len(pcd_list)):
+            # print(indice)
+            pcd_frame = cal_2_scenes(pcd_list, indice, voxel_size=voxel_size, voxelize=voxelize)
+            if pcd_frame is not None:
+                new_pcd_list.append(pcd_frame)
+        pcd_list = new_pcd_list
+    seg_dict = pcd_list[0]
+    seg_dict["group"] = num_to_natural(remove_small_group(seg_dict["group"], th))
+
+
+    points_path = data_path / "points.pth"
+    points_path = str(points_path)
+
+    data_dict = torch.load(points_path)
+    scene_coord = torch.tensor(data_dict["coord"]).cuda().contiguous().float()
+    new_offset = torch.tensor(scene_coord.shape[0]).cuda()
+    gen_coord = torch.tensor(seg_dict["coord"]).cuda().contiguous().float()
+    offset = torch.tensor(gen_coord.shape[0]).cuda()
+    gen_group = seg_dict["group"]
+    
+    indices, dis = pointops.knn_query(1, gen_coord, offset, scene_coord, new_offset)
+    indices = indices.cpu().numpy()
+    group = gen_group[indices.reshape(-1)].astype(np.int16)
+    mask_dis = dis.reshape(-1).cpu().numpy() > 0.6
+    group[mask_dis] = -1
+    group = group.astype(np.int16)
+
+    output_file_path = save_Path / "result.pth"
+    output_file_path = str(output_file_path)
+
+    seg_result = num_to_natural(group)
+    torch.save(seg_result, output_file_path)
+
+    seg_val = np.unique(seg_result)
+    random_color = np.random.randint(0, 256, [seg_val.shape[0], 3], dtype=np.uint8)
+    mapping_color = random_color[seg_result + 1]
+    mapping_color = mapping_color.astype(np.float64) / 255
+
+    pcd = o3d.geometry.PointCloud()
+    pcd.points = o3d.utility.Vector3dVector(np.asarray(data_dict["coord"]))
+    pcd.colors = o3d.utility.Vector3dVector(mapping_color)
+    output_pcd_path = save_Path / "result.ply"
+    output_pcd_path = str(output_pcd_path)
+    o3d.io.write_point_cloud(output_pcd_path, pcd)
+
+def get_args():
+    '''Command line arguments.'''
+
+    parser = argparse.ArgumentParser(
+        description='Segment Anything on ScanNet.')
+    dps_help = 'the path of pointcload directory, which contains points.pth, color directory, depth directory, etc.'
+    parser.add_argument('--data_path', type=str, default='', help=dps_help)
+    parser.add_argument('--save_path', type=str, help='Where to save the pcd results')
+    parser.add_argument('--sam_checkpoint_path', type=str, default='', help='the path of checkpoint for SAM')
+    parser.add_argument('--img_size', default=[640,480])
+    parser.add_argument('--voxel_size', default=0.05)
+    parser.add_argument('--th', default=50, help='threshold of ignoring small groups to avoid noise pixel')
+
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = get_args()
+    mask_generator = SamAutomaticMaskGenerator(build_sam(checkpoint=args.sam_checkpoint_path).to(device="cuda"))
+    voxelize = Voxelize(voxel_size=args.voxel_size, mode="train", keys=("coord", "color", "group"))
+    
+    data_path = Path(args.data_path)
+    save_path = Path(args.save_path)
+    save_path.mkdir(exist_ok=True)
+    seg_pcd_custom(data_path, save_path, mask_generator, args.voxel_size, voxelize, args.th)
+    pass
+
+if __name__ == '__main__':
+    main()
+    pass

--- a/util.py
+++ b/util.py
@@ -5,6 +5,7 @@ import os
 import copy
 from PIL import Image
 import json
+import cv2
 # import clip
 
 
@@ -103,6 +104,12 @@ class Voxelize(object):
             hashed_arr = np.bitwise_xor(hashed_arr, arr[:, j])
         return hashed_arr
 
+
+def save_depth_to_ordinary_image(src: str, dest: str):
+    im = cv2.imread(src, cv2.IMREAD_UNCHANGED)
+    im = im / np.linalg.norm(im)
+    cv2.imwrite(dest, im)
+    pass
 
 def overlap_percentage(mask1, mask2):
     intersection = np.logical_and(mask1, mask2)


### PR DESCRIPTION
Point cloud data can be captured from [3D scanner app](https://apps.apple.com/us/app/id1419913995). This app exports necessary files to SAM3D. 

Follow the steps to capture and test:

1. In 3d scanner app, there are five options to catpure data from the sensor. Choose the second option to capture point.
2. After captured, export all data to your computer. The directory should contain frame_XXX.jpg(s), frame_XXX.json(s), depth_XXX.png(s) and points.ply. The number of frame_XXX.jpg(s) are usually less than frame_XXX.json(s').
3. Use `preprocess_3d_scan.py` to preprocess the files. This will generate a directory including points.pth, color directory, depth directory, pose directory and intrinsics directory.
4.  Use `sam3d_custom.py` to run. This will generate a directory, 2d mask images, result.pth, result.ply.